### PR TITLE
feat(pageInfo): added more details on page info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to this project will be documented in this file.
 ...
 
 ---
+### 1.2.1 - 2022-01-12
+
+### Changed
+
+- PageInfo - added more details on page info payload.
+
+```ts
+{
+	...
+	sizePerPage: 7,
+	currentItem: 1,
+	page: {
+		current: 2,
+		of: 6
+	}
+}
+```
+
+---
 ### 1.2.0 - 2022-01-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You also may use on browser
 
 ```html
 
-<script src="https://cdn.jsdelivr.net/npm/ts-paginate@1.2.0/bundle/index.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ts-paginate@1.2.1/bundle/index.min.js"></script>
 
 ```
 
@@ -73,7 +73,7 @@ const result = paginate({
 	data: dbData,
 	params: {
 		size: 7,
-		after: 'cursor_xyz'
+		after: 'cursor_xya'
 	}
 }).toRest();
 
@@ -82,8 +82,14 @@ console.log(result.pageInfo);
 	hasNextPage: true,
 	hasPreviousPage: true,
 	totalCount: 40,
-	firstCursor: 'cursor_xyz',
-	lastCursor: 'cursor_xyw'
+	sizePerPage: 7,
+	currentItem: 1,
+	page: {
+		current: 2,
+		of: 6
+	},
+	firstCursor: 'cursor_xyb',
+	lastCursor: 'cursor_xyh'
 }`
 
 // using before cursor

--- a/examples/browser.html
+++ b/examples/browser.html
@@ -57,26 +57,30 @@
 </head>
 <body>
 
-	
 	<div class="btns">
 		<button onclick="handlePrev()" title="Goes to previous page on click">Prev</button>
 		<button onclick="handleNext()" title="Goes to next page on click">Next</button>
 		<input type="number" name="size" id="size" value="4" max="21" min="1"  title="Size per page">
 	</div>
+	<p id="page-info">Page info: </p>
 	
 	<div id="root"></div>
-	<!-- <script src="../bundle/index.min.js"></script> -->
-	<script src="https://cdn.jsdelivr.net/npm/ts-paginate@1.2.0/bundle/index.min.js"></script>
+	<script src="../bundle/index.min.js"></script>
+	<!-- <script src="https://cdn.jsdelivr.net/npm/ts-paginate@1.2.0/bundle/index.min.js"></script> -->
 	<script>
 
 		const root = document.getElementById('root');
 		const size = document.getElementById('size');
+		const pageDetails = document.getElementById('page-info');
 
 		// global state to pagination
 		let pageInfo = {
 			hasNextPage: true,
-			hasPreviousPage: false,
-			totalCount: 10,
+			hasPreviousPage: true,
+			totalCount: 21,
+			page: { current: 6, of: 11 },
+			currentItem: 4,
+			sizePerPage: 4,
 			firstCursor: 'cursor_1',
 			lastCursor: 'cursor_4',
 		};
@@ -225,6 +229,9 @@
 				root.innerHTML = root.innerHTML + element;
 			});
 
+			// handle page details
+			pageDetails.innerHTML = `Page: <b>${pageInfo.page.current}</b> of <b>${pageInfo.page.of}</b> Per Page: <b>${pageInfo.sizePerPage}</b> Current Item: <b>${pageInfo.currentItem}</b>`;
+
 		}
 
 		// paginate to backward
@@ -256,6 +263,9 @@
 				var element = `<p><img src="${rel.image}"><b>${rel.id}</b> ${rel.name}</p>`;
 				root.innerHTML = root.innerHTML + element;
 			});
+
+			// handle page details
+			pageDetails.innerHTML = `Page: <b>${pageInfo.page.current}</b> of <b>${pageInfo.page.of}</b> Per Page: <b>${pageInfo.sizePerPage}</b> Current Item: <b>${pageInfo.currentItem}</b>`;
 
 		}
 

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -29,12 +29,20 @@ export interface IPaginateConfig {
 	pageSize: number;
 }
 
+export interface IPage {
+	current: number;
+	of: number;
+}
+
 export interface IPageInfo {
 	totalCount: number;
 	hasNextPage: boolean;
 	hasPreviousPage: boolean;
-	firstCursor?: string,
-	lastCursor?: string
+	sizePerPage: number;
+	currentItem: number;
+	page: IPage;
+	firstCursor?: string;
+	lastCursor?: string;
 }
 
 export interface IPaginate<T> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ts-paginate",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "This package provide pagination to any data records that has id attribute",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/tests/core/pager.spec.ts
+++ b/tests/core/pager.spec.ts
@@ -28,16 +28,22 @@ describe('paginate.ts', () => {
 			hasNextPage: true,
 			hasPreviousPage: true,
 			totalCount: 41,
-			firstCursor: '15',
-			lastCursor: '21'
+			sizePerPage: 7,
+			currentItem: 16,
+			page: {
+				current: 3,
+				of: 6
+			},
+			firstCursor: '16',
+			lastCursor: '22'
 		});
 
 		expect(result.data).toHaveLength(7);
-		expect(result.data[0].id).toBe('15');
-		expect(result.data[6].id).toBe('21');
+		expect(result.data[0].id).toBe('16');
+		expect(result.data[6].id).toBe('22');
 	});
 
-	it('should paginate 7 items before position 30º', () => {
+	it('should paginate 7 items after position 30º', () => {
 		const result = paginate({
 			data: fakeData,
 			params: {
@@ -50,13 +56,19 @@ describe('paginate.ts', () => {
 			hasNextPage: true,
 			hasPreviousPage: true,
 			totalCount: 41,
-			firstCursor: '30',
-			lastCursor: '36'
+			sizePerPage: 7,
+			currentItem: 31,
+			page: {
+				current: 5,
+				of: 6
+			},
+			firstCursor: '31',
+			lastCursor: '37'
 		})
 
 		expect(result.data).toHaveLength(7);
-		expect(result.data[0].id).toBe('30');
-		expect(result.data[6].id).toBe('36');
+		expect(result.data[0].id).toBe('31');
+		expect(result.data[6].id).toBe('37');
 	});
 
 	it('should throw if try get data after last cursor', () => {
@@ -83,17 +95,16 @@ describe('paginate.ts', () => {
 
 		const cursor = fakeData[0].id;
 
-		const result = paginate({
-			data: fakeData,
-			params: {
-				before: cursor
-			}
-		}).toRest();
-
-	expect(result.data).toHaveLength(1);
-	expect(result.data[0]).toEqual(fakeData[0]);
-	expect(result.pageInfo.hasPreviousPage).toBeFalsy();
-	expect(result.pageInfo.hasNextPage).toBeTruthy();
+		try {
+			paginate({
+				   data: fakeData,
+				   params: {
+					   before: cursor
+				   }
+			}).toRest();
+		} catch (error: any) {
+			expect(error.message).toBe('there is not data before cursor: 1')
+		}
 	
 });
 
@@ -109,14 +120,20 @@ describe('paginate.ts', () => {
 
 		expect(result.pageInfo).toEqual({
 			hasNextPage: true,
-			hasPreviousPage: false,
+			hasPreviousPage: true,
 			totalCount: 41,
-			firstCursor: '1',
-			lastCursor: '3'
+			sizePerPage: 3,
+			currentItem: 2,
+			page: {
+				current: 2,
+				of: 14
+			},
+			firstCursor: '2',
+			lastCursor: '4'
 		})
 		expect(result.data).toHaveLength(3);
-		expect(result.data[0].id).toBe('1');
-		expect(result.data[2].id).toBe('3');
+		expect(result.data[0].id).toBe('2');
+		expect(result.data[2].id).toBe('4');
 	});
 
 	it('should paginate 3 items 1-3', () => {
@@ -131,6 +148,12 @@ describe('paginate.ts', () => {
 			hasNextPage: true,
 			hasPreviousPage: false,
 			totalCount: 41,
+			sizePerPage: 3,
+			currentItem: 1,
+			page: {
+				current: 1,
+				of: 14
+			},
 			firstCursor: '1',
 			lastCursor: '3'
 		})
@@ -147,12 +170,18 @@ describe('paginate.ts', () => {
 				after: '35'
 			}
 		}).toRest();
-		
+
 		expect(result.pageInfo).toEqual({
 			hasNextPage: false,
 			hasPreviousPage: true,
 			totalCount: 41,
-			firstCursor: '35',
+			sizePerPage: 7,
+			currentItem: 36,
+			page: {
+				current: 6,
+				of: 6
+			},
+			firstCursor: '36',
 			lastCursor: '41'
 		});
 	});
@@ -167,16 +196,43 @@ describe('paginate.ts', () => {
 			}
 		}).toRest();
 
-		expect(result.data).toEqual([{ id: '33' }, { id: '34' }, { id: '35' }]);	
+		expect(result.data).toEqual([{ id: '32' }, { id: '33' }, { id: '34' }]);	
 
 		expect(result.pageInfo).toEqual({
 			hasNextPage: true,
 			hasPreviousPage: true,
 			totalCount: 41,
-			firstCursor: '33',
-			lastCursor: '35'
+			sizePerPage: 3,
+			currentItem: 32,
+			page: {
+				current: 11,
+				of: 14
+			},
+			firstCursor: '32',
+			lastCursor: '34'
 		});
 	});
+
+	it('should throw if try to get data before first cursor', () => {
+
+		
+		const data = [{ id: '1' }];
+		expect.assertions(1);
+		try {
+			paginate({
+				data,
+				params: {
+					size: 3,
+					before: '1'
+				}
+			}).toRest();
+		} catch (error: any) {
+			expect(error.message).toBe('there is not data before cursor: 1')
+		}
+
+
+	});
+
 
 	it('should throws if provide before and after', () => {
 		expect.assertions(1);

--- a/tests/example/custom-key-example.spec.ts
+++ b/tests/example/custom-key-example.spec.ts
@@ -22,6 +22,12 @@ describe('example', () => {
 			hasNextPage: false,
 			hasPreviousPage: false,
 			totalCount: 0,
+			currentItem: 0,
+			sizePerPage: 0,
+			page: {
+				current: 0,
+				of: 0,
+			},
 			firstCursor: undefined,
 			lastCursor: undefined
 		}
@@ -35,17 +41,18 @@ describe('example', () => {
 
 		const cursor = data.original[0].__cursor;
 
-		const result = pager.paginate<IUser>({
-			data: data.original,
-			params: {
-				before: cursor
-			}
-		}).toRest();
+		try {
+			
+			pager.paginate<IUser>({
+				data: data.original,
+				params: {
+					before: cursor
+				}
+			}).toRest();
 
-	expect(result.data).toHaveLength(1);
-	expect(result.data[0]).toEqual(data.original[0]);
-	expect(result.pageInfo.hasPreviousPage).toBeFalsy();
-	expect(result.pageInfo.hasNextPage).toBeTruthy();
+		} catch (error: any) {
+			expect(error.message).toBe('there is not data before cursor: 1');
+		}
 	
 });
 
@@ -102,7 +109,7 @@ describe('example', () => {
 		data.payload = result.data;
 		data.pageInfo = result.pageInfo;
 
-		expect(result.data).toHaveLength(13);
+		expect(result.data).toHaveLength(11);
 		expect(result.pageInfo.hasPreviousPage).toBeTruthy();
 		expect(result.pageInfo.hasNextPage).toBeFalsy();
 
@@ -160,10 +167,10 @@ describe('example', () => {
 			}
 		}).toGql();
 
-		expect(result.data[0].node).toEqual(data.original[0]);
-		expect(result.data[0].cursor).toEqual(data.original[0].__cursor);
+		expect(result.data[0].node).toEqual(data.original[1]);
+		expect(result.data[0].cursor).toEqual(data.original[1].__cursor);
 		expect(result.data).toHaveLength(10);
-		expect(result.pageInfo.hasPreviousPage).toBeFalsy();
+		expect(result.pageInfo.hasPreviousPage).toBeTruthy();
 		expect(result.pageInfo.hasNextPage).toBeTruthy();
 
 	});

--- a/tests/example/mongo-example.spec.ts
+++ b/tests/example/mongo-example.spec.ts
@@ -22,6 +22,12 @@ describe('example', () => {
 			hasNextPage: false,
 			hasPreviousPage: false,
 			totalCount: 0,
+			currentItem: 0,
+			sizePerPage: 0,
+			page: {
+				current: 0,
+				of: 0,
+			},
 			firstCursor: undefined,
 			lastCursor: undefined
 		}
@@ -34,18 +40,20 @@ describe('example', () => {
 	it('should return first item data if try to go back', () => {
 
 		const cursor = data.original[0]._id;
+		expect.assertions(1);
+		try {
+			
+			pager.paginate({
+				data: data.original,
+				params: {
+					before: cursor
+				}
+			}).toRest();
 
-		const result = pager.paginate({
-			data: data.original,
-			params: {
-				before: cursor
-			}
-		}).toRest();
+		} catch (error: any) {
+			expect(error.message).toBe('there is not data before cursor: 1')
+		}
 
-	expect(result.data).toHaveLength(1);
-	expect(result.data[0]).toEqual(data.original[0]);
-	expect(result.pageInfo.hasPreviousPage).toBeFalsy();
-	expect(result.pageInfo.hasNextPage).toBeTruthy();
 	
 });
 
@@ -102,7 +110,7 @@ describe('example', () => {
 		data.payload = result.data;
 		data.pageInfo = result.pageInfo;
 
-		expect(result.data).toHaveLength(13);
+		expect(result.data).toHaveLength(11);
 		expect(result.pageInfo.hasPreviousPage).toBeTruthy();
 		expect(result.pageInfo.hasNextPage).toBeFalsy();
 
@@ -160,10 +168,10 @@ describe('example', () => {
 			}
 		}).toGql();
 
-		expect(result.data[0].node).toEqual(data.original[0]);
-		expect(result.data[0].cursor).toEqual(data.original[0]._id);
+		expect(result.data[0].node).toEqual(data.original[1]);
+		expect(result.data[0].cursor).toEqual(data.original[1]._id);
 		expect(result.data).toHaveLength(10);
-		expect(result.pageInfo.hasPreviousPage).toBeFalsy();
+		expect(result.pageInfo.hasPreviousPage).toBeTruthy();
 		expect(result.pageInfo.hasNextPage).toBeTruthy();
 
 	});

--- a/tests/example/simple-example.spec.ts
+++ b/tests/example/simple-example.spec.ts
@@ -19,6 +19,12 @@ describe('example', () => {
 			hasNextPage: false,
 			hasPreviousPage: false,
 			totalCount: 0,
+			currentItem: 0,
+			sizePerPage: 0,
+			page: {
+				current: 0,
+				of: 0,
+			},
 			firstCursor: undefined,
 			lastCursor: undefined
 		}
@@ -28,21 +34,25 @@ describe('example', () => {
 		data.original = makeFakeUsers(40);
 	});
 
-	it('should return first item data if try to go back', () => {
+	it('should throw error if try back and no exist previous page', () => {
 
 			const cursor = data.original[0].id;
 
-			const result = pager.paginate({
+		expect.assertions(1);
+
+		try {
+
+			pager.paginate({
 				data: data.original,
 				params: {
 					before: cursor
 				}
 			}).toRest();
+			
+		} catch (error: any) {
+			expect(error.message).toBe('there is not data before cursor: 1')
+		}
 
-		expect(result.data).toHaveLength(1);
-		expect(result.data[0]).toEqual(data.original[0]);
-		expect(result.pageInfo.hasPreviousPage).toBeFalsy();
-		expect(result.pageInfo.hasNextPage).toBeTruthy();
 		
 	});
 
@@ -52,7 +62,7 @@ describe('example', () => {
 			data: data.original,
 			params: {
 				size: 20,
-				before: data.original[9].id
+				before: data.original[10].id
 			}
 		}).toGql();
 
@@ -118,7 +128,7 @@ describe('example', () => {
 		data.payload = result.data;
 		data.pageInfo = result.pageInfo;
 
-		expect(result.data).toHaveLength(13);
+		expect(result.data).toHaveLength(11);
 		expect(result.pageInfo.hasPreviousPage).toBeTruthy();
 		expect(result.pageInfo.hasNextPage).toBeFalsy();
 
@@ -162,7 +172,7 @@ describe('example', () => {
 
 		expect(result.data).toHaveLength(15);
 		expect(result.pageInfo.hasPreviousPage).toBeTruthy();
-		expect(result.pageInfo.hasNextPage).toBeFalsy();
+		expect(result.pageInfo.hasNextPage).toBeTruthy();
 
 	});
 
@@ -176,10 +186,10 @@ describe('example', () => {
 			}
 		}).toGql();
 
-		expect(result.data[0].node).toEqual(data.original[0]);
-		expect(result.data[0].cursor).toEqual(data.original[0].id);
+		expect(result.data[0].node).toEqual(data.original[1]);
+		expect(result.data[0].cursor).toEqual(data.original[1].id);
 		expect(result.data).toHaveLength(10);
-		expect(result.pageInfo.hasPreviousPage).toBeFalsy();
+		expect(result.pageInfo.hasPreviousPage).toBeTruthy();
 		expect(result.pageInfo.hasNextPage).toBeTruthy();
 
 	});
@@ -190,7 +200,7 @@ describe('example', () => {
 			data: data.original,
 			params: {
 				size: 20,
-				after: data.original[31].id
+				after: data.original[30].id
 			}
 		}).toGql();
 

--- a/tests/utils/validations.util.spec.ts
+++ b/tests/utils/validations.util.spec.ts
@@ -57,10 +57,16 @@ describe('validation.util', () => {
 			const result = pager({ data: [] }).toRest();
 
 			expect(result.pageInfo).toEqual({
+				currentItem: 0,
 				firstCursor: undefined,
 				lastCursor: undefined,
 				hasNextPage: false,
 				hasPreviousPage: false,
+				page: {
+					current: 0,
+					of: 0
+				},
+				sizePerPage: 0,
 				totalCount: 0
 			});
 
@@ -69,15 +75,21 @@ describe('validation.util', () => {
 		it('should have hasNextPage and hasPreviousPage', () => {
 			
 			const originalData = [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }];
-			const dataPayload = [{ id: '2' }, { id: '3' }];
+			const dataPayload = [{ id: '3' }, { id: '4' }];
 
 			const result = pager({ data: originalData, params: { after: '2', size: 2 } }).toRest();
 
 			expect(result.pageInfo).toEqual({
-				firstCursor: '2',
-				lastCursor: '3',
+				currentItem: 3,
+				firstCursor: '3',
+				lastCursor: '4',
 				hasNextPage: true,
 				hasPreviousPage: true,
+				page: {
+					current: 2,
+					of: 3
+				},
+				sizePerPage: 2,
 				totalCount: 5
 			});
 			expect(result.data).toEqual(dataPayload);
@@ -92,10 +104,16 @@ describe('validation.util', () => {
 			const result = pager({ data: originalData, params: { size: 3 } }).toRest();
 
 			expect(result.pageInfo).toEqual({
+				currentItem: 1,
 				lastCursor: '3',
 				firstCursor: '1',
 				hasNextPage: true,
 				hasPreviousPage: false,
+				page: {
+					current: 1,
+					of: 2
+				},
+				sizePerPage: 3,
 				totalCount: 5
 			});
 			expect(result.data).toEqual(dataPayload);
@@ -105,15 +123,21 @@ describe('validation.util', () => {
 		it('should have hasPreviousPage and not hasNextPage', () => {
 			
 			const originalData = [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }];
-			const dataPayload = [{ id: '3' }, { id: '4' }, { id: '5' }];
+			const dataPayload = [{ id: '4' }, { id: '5' }];
 
 			const result = pager({ data: originalData, params: { after: '3', size: 3 } }).toRest();
 
 			expect(result.pageInfo).toEqual({
+				currentItem: 4,
 				lastCursor: '5',
-				firstCursor: '3',
+				firstCursor: '4',
 				hasNextPage: false,
 				hasPreviousPage: true,
+				page: {
+					current: 2,
+					of: 2
+				},
+				sizePerPage: 3,
 				totalCount: 5
 			});
 			expect(result.data).toEqual(dataPayload);


### PR DESCRIPTION
Added more details on page info.
Now when using the `after` x cursor, the specific value of x will not be in the return. only data after him.

```ts
{
        ...
	sizePerPage: 7,
	currentItem: 1,
	page: {
		current: 2,
		of: 6
	},
}

```